### PR TITLE
Replace user ID lookup button with reactive curl command

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,10 +656,12 @@
     }
 
     function buildCurlCommand(slug) {
-      const escapedSlug = slug.replace(/'/g, "'\\''");
+      const body = JSON.stringify({
+        query: `{ user(input: { selector: { slug: ${JSON.stringify(slug)} } }) { result { _id } } }`
+      });
       return `curl -s -X POST https://www.lesswrong.com/graphql \\
   -H 'Content-Type: application/json' \\
-  -d '{"query": "{ user(input: { selector: { slug: \\"${escapedSlug}\\" } }) { result { _id } } }"}'`;
+  -d '${body.replace(/'/g, "'\\''")}'`;
     }
 
     function updateCurlCommand() {
@@ -715,6 +717,12 @@
       navigator.clipboard.writeText(buildCurlCommand(slug)).then(() => {
         copiedToast.classList.add('show');
         setTimeout(() => copiedToast.classList.remove('show'), 2000);
+      }).catch(() => {
+        const range = document.createRange();
+        range.selectNodeContents(curlCommandText);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
       });
     });
 


### PR DESCRIPTION
## Summary
- Removed the broken "Look up" button that opened a GraphQL URL now showing only an Apollo splash page
- Replaced it with a curl command that appears automatically as the user types a username slug
- Added a "Copy" button to easily copy the curl command to clipboard

Fixes #7

## Test plan
- [ ] Open the tool, verify the user ID section shows a text input for username slug (no button)
- [ ] Type a username (e.g. "adamzerner") and verify the curl command appears and updates as you type
- [ ] Click the "Copy" button and verify the curl command is copied to clipboard
- [ ] Clear the username slug field and verify the curl command box disappears
- [ ] Switch to a view that doesn't show the user ID field and back, verify curl command state resets properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)