### PR TITLE
Change default user slug placeholder to 'brendan-long'

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
         <p class="info-text" id="userHelp">Don't know your user ID? Enter a username below and run the curl command to look it up.</p>
         <div style="margin-top: 0.5rem">
           <label for="userSlug" style="margin-bottom: 0.25rem">Username slug <span class="hint">(for lookup only)</span></label>
-          <input type="text" id="userSlug" placeholder="e.g. adamzerner">
+          <input type="text" id="userSlug" placeholder="e.g. brendan-long">
           <div class="curl-command hidden" id="curlCommandBox">
             <div class="curl-command-header">
               <span>Run this in your terminal to get the user ID:</span>


### PR DESCRIPTION
## Summary
- Changes the username slug placeholder from "e.g. adamzerner" to "e.g. brendan-long"

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)